### PR TITLE
feat: Add release workflow to build and push images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
-env:
-  AWS_REGION: eu-west-1
-
 permissions:
   contents: write
   id-token: write
@@ -39,7 +36,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/connect-ecr-gh-actions-access
           role-session-name: connect-ecr-gh-actions-access
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
       - name: Build and push
@@ -52,7 +49,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          tags: ${{format('{0}.dkr.ecr.{1}.{2}:{3}-{4}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, matrix.arch, github.ref_name)}}
+          tags: ${{format('{0}.dkr.ecr.{1}.{2}:{3}-{4}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, matrix.arch, github.ref_name)}}
 
   build-merge-arch-images:
     runs-on: ubuntu-latest
@@ -71,13 +68,13 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/connect-ecr-gh-actions-access
           role-session-name: connect-ecr-gh-actions-access
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v2
       - name: pull images
         run: |
-          docker pull --platform linux/amd64 ${{format('{0}.dkr.ecr.{1}.{2}:amd64-{3}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, github.ref_name)}}
-          docker pull --platform linux/arm64 ${{format('{0}.dkr.ecr.{1}.{2}:arm64-{3}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, github.ref_name)}}
+          docker pull --platform linux/amd64 ${{format('{0}.dkr.ecr.{1}.{2}:amd64-{3}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, github.ref_name)}}
+          docker pull --platform linux/arm64 ${{format('{0}.dkr.ecr.{1}.{2}:arm64-{3}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, github.ref_name)}}
       - name: Merge images
         run: |
           docker manifest create $IMAGE --amend $IMAGE_AMD64 --amend $IMAGE_ARM64
@@ -85,6 +82,6 @@ jobs:
           docker manifest annotate $IMAGE $IMAGE_ARM64  --os linux --arch arm64
           docker manifest push $IMAGE
         env:
-          IMAGE_AMD64: ${{format('{0}.dkr.ecr.{1}.{2}:amd64-{3}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, github.ref_name)}}
-          IMAGE_ARM64: ${{format('{0}.dkr.ecr.{1}.{2}:arm64-{3}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, github.ref_name)}}
-          IMAGE: ${{format('{0}.dkr.ecr.{1}.{2}:{3}', secrets.AWS_ACCOUNT_ID, env.AWS_REGION, matrix.repo, github.ref_name)}}
+          IMAGE_AMD64: ${{format('{0}.dkr.ecr.{1}.{2}:amd64-{3}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, github.ref_name)}}
+          IMAGE_ARM64: ${{format('{0}.dkr.ecr.{1}.{2}:arm64-{3}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, github.ref_name)}}
+          IMAGE: ${{format('{0}.dkr.ecr.{1}.{2}:{3}', secrets.AWS_ACCOUNT_ID, secrets.AWS_REGION, matrix.repo, github.ref_name)}}


### PR DESCRIPTION
### Summary
- This PR adds the `release` GitHub Actions workflow (similar to the workflow pattern used elsewhere) to build and push multi-arch ECR images.
- NOTE: This isn't currently building a `spiffe-enable-init` image yet.