### PR TITLE
Add debug UI injection

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -180,8 +180,6 @@ func (a *spiffeEnableWebhook) Handle(ctx context.Context, req admission.Request)
 		Value: spiffeWLSocket,
 	}
 
-	logger.Info("Observed pod annotations", "annotations", pod.Annotations)
-
 	// Check for a debug annotation
 	debugAnnotationValue, debugAnnotationExists := pod.Annotations[debugAnnotation]
 


### PR DESCRIPTION
If the `spiffe.cofide.io/debug` annotation is set to `true`, a debug UI sidecar container is injected. It serves on port 8080.

relies on https://github.com/cofide/spiffe-enable/pull/2