### PR TITLE
Update the cofide-agent XDS service name

### DIFF
--- a/internal/const/const.go
+++ b/internal/const/const.go
@@ -25,7 +25,7 @@ const (
 // Cofide Agent
 const (
 	AgentXDSPort    = 18001
-	AgentXDSService = "cofide-agent.cofide.svc.cluster.local"
+	AgentXDSService = "cofide-agent-xds.cofide.svc.cluster.local"
 )
 
 // SPIFFE Enable


### PR DESCRIPTION
We've updated the name of the `cofide-agent` XDS service.