### PR TITLE
Uprev Helm chart version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ helm install \
   spiffe-enable cofide/spiffe-enable \
   --namespace cofide \
   --create-namespace \
-  --version v0.1.0
+  --version v0.1.3
 ```
 
 ## Development


### PR DESCRIPTION
Points to latest version (`v0.1.3`)