### PR TITLE
chore: bump go to 1.25.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cofide/spiffe-enable
 
-go 1.25.0
+go 1.25.5
 
 require (
 	github.com/evanphx/json-patch v5.9.11+incompatible


### PR DESCRIPTION
It was bumped to 1.25.0 by dependabot, which has several vulnerabilities.
