### PR TITLE
fix: Helper config should use `health_checks`

### DIFF
--- a/internal/helper/config.go
+++ b/internal/helper/config.go
@@ -49,7 +49,7 @@ type SPIFFEHelperConfig struct {
 	IncludeFederatedDomains  bool                     `hcl:"include_federated_domains"`
 	RenewSignal              string                   `hcl:"renew_signal"`
 	DaemonMode               *bool                    `hcl:"daemon_mode"`
-	HealthCheck              SPIFFEHelperHealthConfig `hcl:"health_check,block"`
+	HealthCheck              SPIFFEHelperHealthConfig `hcl:"health_checks,block"`
 	Hint                     string                   `hcl:"hint"`
 
 	// x509 configuration


### PR DESCRIPTION
* Fixes discrepancy between expected config block `health_checks` and HCL value which was erroneously `health_check`

This manifested in an injected sidecar failure as:

```
time="2026-02-06T09:54:21Z" level=error msg="invalid configuration" error="unknown top level key(s): health_check" system=spiffe-helper
```